### PR TITLE
Bug fixes and some significant changes

### DIFF
--- a/kdmlib/kademlia.go
+++ b/kdmlib/kademlia.go
@@ -15,7 +15,7 @@ type Kademlia struct {
 	closest           []AddressTriple
 	askedClosest      []AddressTriple
 	gotResultBack     []AddressTriple
-	nodeId            string
+	nodeID            string
 	rt                RoutingTable
 	network           Network
 	alpha             int
@@ -28,10 +28,10 @@ type Kademlia struct {
 }
 
 //Initializes a Kademlia struct, along with its necessary variables
-func NewKademliaInstance(nw *Network, nodeId string, alpha int, k int, rt RoutingTable, fileChannel chan fileUtilsKademlia.Order, fileMap fileUtilsKademlia.FileMap) *Kademlia {
+func NewKademliaInstance(nw *Network, nodeID string, alpha int, k int, rt RoutingTable, fileChannel chan fileUtilsKademlia.Order, fileMap fileUtilsKademlia.FileMap) *Kademlia {
 	kademlia := &Kademlia{}
 	kademlia.network = *nw
-	kademlia.nodeId = nodeId
+	kademlia.nodeID = nodeID
 	kademlia.rt = rt
 	kademlia.alpha = alpha
 	kademlia.k = k
@@ -61,11 +61,11 @@ func (kademlia *Kademlia) lookupListener(resultChannel chan interface{}) ([]Addr
 			//1. Successful LookupContact
 			//2. Successful LookupData, that was not able to locate data
 			case []AddressTriple:
-				fmt.Println("Answer: ", answer)
+				PrintListOfContacts("RESULT: ", answer)
 				return answer, AddressTriple{}
 				//A slice of bytes is only written to the channel in case the successful LookupData was able to found the file
 			case AddressTriple:
-				fmt.Println("Contact with Data: ", answer)
+				fmt.Println("Contact with Data: '"+ConvertToHexAddr(answer.Id)+"'", answer.Ip+":"+answer.Port)
 				return nil, answer
 			}
 		}
@@ -75,7 +75,7 @@ func (kademlia *Kademlia) lookupListener(resultChannel chan interface{}) ([]Addr
 //Performs operations when the slice of contacts comes back from the network.
 func (kademlia *Kademlia) handleContactAnswer(order LookupOrder, answerList []AddressTriple, resultChannel chan interface{}, lookupWorkerChannel chan LookupOrder) {
 	if len(answerList) != 0 {
-		fmt.Println("Got some contacts back: ", answerList)
+		PrintListOfContacts("Got some contacts back: ", answerList)
 		//Refresh the list of closest contacts, according to the answer
 		kademlia.refreshClosest(answerList, order.Target)
 
@@ -95,13 +95,11 @@ func (kademlia *Kademlia) handleContactAnswer(order LookupOrder, answerList []Ad
 }
 
 //User by the Lookup function to perform FIND_NODE and FIND_DATA RPC calls.
-func (kademlia *Kademlia) lookupWorker(routineId int, lookupWorkerChannel chan LookupOrder, resultChannel chan interface{}) {
-	fmt.Println("Lookup goroutine ", routineId, " started...")
+func (kademlia *Kademlia) lookupWorker(lookupWorkerChannel chan LookupOrder, resultChannel chan interface{}) {
 
 	//Execute orders from the channel
 	for order := range lookupWorkerChannel {
 
-		fmt.Println("Order: ", order)
 		switch order.LookupType {
 
 		case ContactLookup:
@@ -114,7 +112,7 @@ func (kademlia *Kademlia) lookupWorker(routineId int, lookupWorkerChannel chan L
 				//Handle the operations in a separate function
 				kademlia.handleContactAnswer(order, contacts, resultChannel, lookupWorkerChannel)
 			} else {
-				fmt.Println("TIMEOUT")
+				fmt.Println("FIND_NODE RPC from node '" + ConvertToHexAddr(kademlia.nodeID) + "' to node '" + ConvertToHexAddr(order.Contact.Id) + "' timed out")
 				kademlia.askNextContact(order.Target, order.LookupType, lookupWorkerChannel)
 			}
 
@@ -130,7 +128,7 @@ func (kademlia *Kademlia) lookupWorker(routineId int, lookupWorkerChannel chan L
 					kademlia.handleContactAnswer(order, contacts, resultChannel, lookupWorkerChannel)
 				}
 			} else {
-				fmt.Println("TIMEOUT")
+				fmt.Println("FIND_DATA RPC from node '" + ConvertToHexAddr(kademlia.nodeID) + "' to node '" + ConvertToHexAddr(order.Contact.Id) + "' timed out")
 				kademlia.askNextContact(order.Target, order.LookupType, lookupWorkerChannel)
 			}
 		}
@@ -140,7 +138,12 @@ func (kademlia *Kademlia) lookupWorker(routineId int, lookupWorkerChannel chan L
 
 		//Check if all nodes have been asked and if all nodes have responded/timed out
 		if kademlia.askedAllContacts() && len(resultChannel) == 0 {
-			fmt.Println("Asked ALL!")
+			switch order.LookupType {
+			case ContactLookup:
+				fmt.Println("FIND_NODE procedure, initiated by node '" + ConvertToHexAddr(kademlia.nodeID) + "' was finalized")
+			case DataLookup:
+				fmt.Println("FIND_DATA procedure, initiated by node '" + ConvertToHexAddr(kademlia.nodeID) + "' was finalized")
+			}
 			resultChannel <- kademlia.closest
 		}
 	}
@@ -167,7 +170,7 @@ func (kademlia *Kademlia) LookupAlgorithm(target string, lookupType int) ([]Addr
 		kademlia.closest = append(kademlia.closest, e.Triple)
 	}
 
-	fmt.Println("RT: ", kademlia.closest)
+	PrintListOfContacts("RT: ", kademlia.closest)
 
 	//Check if the list of closest is empty
 	//If true, return nil
@@ -178,7 +181,7 @@ func (kademlia *Kademlia) LookupAlgorithm(target string, lookupType int) ([]Addr
 
 	//Start at most Alpha lookup workers
 	for i := 0; i < kademlia.alpha; i++ {
-		go kademlia.lookupWorker(i, lookupWorkerChannel, resultChannel)
+		go kademlia.lookupWorker(lookupWorkerChannel, resultChannel)
 	}
 
 	//Loop through the closest contacts from the routing table and pass an order to the lookup channel
@@ -190,7 +193,7 @@ func (kademlia *Kademlia) LookupAlgorithm(target string, lookupType int) ([]Addr
 	}
 
 	for i := 0; i < kademlia.alpha-len(kademlia.closest); i++ {
-		lookupWorkerChannel <- LookupOrder{lookupType, AddressTriple{"0", "00", "00000000"}, target}
+		lookupWorkerChannel <- LookupOrder{lookupType, AddressTriple{"0", "00", GenerateZeroID(len(kademlia.nodeID))}, target}
 	}
 
 	//Start a listener function, which returns the desired answer
@@ -228,8 +231,7 @@ type StoreOrder struct {
 }
 
 //Used to send STORE RPC to nodes.
-func (kademlia *Kademlia) storeWorker(routineId int, storeWorkerChannel chan StoreOrder, resultChannel chan bool) {
-	fmt.Println("Lookup goroutine ", routineId, " started...")
+func (kademlia *Kademlia) storeWorker(storeWorkerChannel chan StoreOrder, resultChannel chan bool) {
 
 	//Execute orders from the channel
 	for order := range storeWorkerChannel {
@@ -253,9 +255,9 @@ func (kademlia *Kademlia) storeListener(resultChannel chan bool, expectedNumAnsw
 		case answer := <-resultChannel:
 			answersReturned++
 			if answer == true {
-				fmt.Println("SendStore succeeded")
+				fmt.Println("STORE succeeded")
 			} else {
-				fmt.Println("SendStore failed")
+				fmt.Println("STORE failed")
 			}
 			//Return when all answers are received
 			if answersReturned == expectedNumAnswers {
@@ -270,10 +272,9 @@ func (kademlia *Kademlia) storeListener(resultChannel chan bool, expectedNumAnsw
 func (kademlia *Kademlia) StoreData(fileName string) {
 	fileNameHash := fileName
 
-	//TODO: add fileMap check
 	//Check whether the file exists.
 	//If yes, get the list of closest and send the file to these nodes.
-	if true {
+	if kademlia.network.fileMap.IsPresent(fileName) {
 		contacts, _ := kademlia.LookupAlgorithm(fileNameHash, ContactLookup)
 		if contacts != nil {
 
@@ -283,7 +284,7 @@ func (kademlia *Kademlia) StoreData(fileName string) {
 
 			//Start at most Alpha store workers
 			for i := 0; i < kademlia.alpha && i < len(contacts); i++ {
-				go kademlia.storeWorker(i, storeWorkerChannel, resultChannel)
+				go kademlia.storeWorker(storeWorkerChannel, resultChannel)
 			}
 
 			//Loop through the list of closest and send orders to the store channel
@@ -294,7 +295,7 @@ func (kademlia *Kademlia) StoreData(fileName string) {
 			kademlia.storeListener(resultChannel, len(contacts))
 
 		} else {
-			fmt.Println("Contacts are empty. Something went wrong")
+			fmt.Println("Contacts are empty! Something went wrong...")
 		}
 
 	} else {
@@ -309,11 +310,8 @@ func (kademlia *Kademlia) askNextContact(target string, lookupType int, lookupWo
 
 	nextContact := kademlia.getNextContact()
 	if nextContact != nil {
-		fmt.Println("Next ", nextContact)
 		kademlia.askedClosest = append(kademlia.askedClosest, *nextContact)
 		lookupWorkerChannel <- LookupOrder{lookupType, *nextContact, target}
-	} else {
-		fmt.Println("No more to ask")
 	}
 
 	kademlia.lock.Unlock()
@@ -341,14 +339,16 @@ func (kademlia *Kademlia) refreshClosest(newContacts []AddressTriple, target str
 	//Check for new contacts
 	for i := range newContacts {
 		elementExists := false
-		for j := range kademlia.closest {
-			if kademlia.closest[j].Id == newContacts[i].Id {
-				elementExists = true
+		if newContacts[i].Id != kademlia.nodeID {
+			for j := range kademlia.closest {
+				if kademlia.closest[j].Id == newContacts[i].Id {
+					elementExists = true
+				}
 			}
-		}
-		if !elementExists {
-			elementsAlreadyPresent = false
-			kademlia.closest = append(kademlia.closest, newContacts[i])
+			if !elementExists {
+				elementsAlreadyPresent = false
+				kademlia.closest = append(kademlia.closest, newContacts[i])
+			}
 		}
 	}
 

--- a/kdmlib/kademlia_lookupalgo_test.go
+++ b/kdmlib/kademlia_lookupalgo_test.go
@@ -2,6 +2,7 @@ package kdmlib
 
 import (
 	"Kademlia---P2P-DFS/kdmlib/fileutils"
+	"math/rand"
 	"testing"
 	"time"
 )
@@ -74,6 +75,69 @@ func TestKademlia_LookupAlgorithm(t *testing.T) {
 			t.Error("Difference in slices")
 			t.Fail()
 		}
+	}
+
+	if contactWithData.Id != "" {
+		t.Error("Did not expect a data return")
+		t.Fail()
+	}
+}
+
+func TestKademlia_LookupAlgorithm_160(t *testing.T) {
+
+	time.Sleep(time.Second * 2)
+
+	testContacts := []AddressTriple{
+		{"127.0.0.1", "22000", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "22001", GenerateRandID(int64(rand.Intn(100)), 160)},
+		{"127.0.0.1", "22002", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "22003", GenerateRandID(int64(rand.Intn(100)), 160)},
+		{"127.0.0.1", "22004", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "22005", GenerateRandID(int64(rand.Intn(100)), 160)},
+		{"127.0.0.1", "22006", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "22007", GenerateRandID(int64(rand.Intn(100)), 160)}}
+
+	nodeId1 := testContacts[0].Id
+	port1 := testContacts[0].Port
+	nodeId2 := testContacts[4].Id
+	port2 := testContacts[4].Port
+	nodeId3 := testContacts[6].Id
+	port3 := testContacts[6].Port
+
+	targetContact := testContacts[7]
+
+	rt1 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId1)
+	for _, e := range testContacts[1:5] {
+		rt1.GiveOrder(OrderForRoutingTable{ADD, e, false})
+	}
+
+	time.Sleep(time.Second * 1)
+
+	rt2 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId2)
+	for _, e := range testContacts[2:7] {
+		rt2.GiveOrder(OrderForRoutingTable{ADD, e, false})
+	}
+
+	time.Sleep(time.Second * 1)
+
+	rt3 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId2)
+	for _, e := range testContacts[2:] {
+		rt3.GiveOrder(OrderForRoutingTable{ADD, e, false})
+	}
+
+	time.Sleep(time.Second * 1)
+
+	chanPin1, chanFile1, fileMap1 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
+	chanPin2, chanFile2, fileMap2 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
+	chanPin3, chanFile3, fileMap3 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
+
+	nw1 := InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, true, chanFile1, chanPin1, fileMap1)
+	InitNetwork(port2, "127.0.0.1", rt2, nodeId2, false, true, chanFile2, chanPin2, fileMap2)
+	InitNetwork(port3, "127.0.0.1", rt3, nodeId3, false, true, chanFile3, chanPin3, fileMap3)
+
+	testKademlia := NewKademliaInstance(nw1, nodeId1, ALPHA, K, rt1, chanFile1, fileMap1)
+
+	contacts, contactWithData := testKademlia.LookupAlgorithm(targetContact.Id, ContactLookup)
+
+	if len(contacts) != 7 {
+		t.Error("Expected to get 7 contacts back, got", len(contacts))
+		t.Fail()
 	}
 
 	if contactWithData.Id != "" {

--- a/kdmlib/kademlia_lookupalgo_test.go
+++ b/kdmlib/kademlia_lookupalgo_test.go
@@ -54,9 +54,9 @@ func TestKademlia_LookupAlgorithm(t *testing.T) {
 	chanPin2, chanFile2, fileMap2 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 	chanPin3, chanFile3, fileMap3 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 
-	InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, chanFile1, chanPin1, fileMap1)
-	InitNetwork(port3, "127.0.0.1", rt3, nodeId3, false, chanFile3, chanPin3, fileMap3)
-	nw2 := InitNetwork(port2, "127.0.0.1", rt2, nodeId2, true, chanFile2, chanPin2, fileMap2)
+	InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, true, chanFile1, chanPin1, fileMap1)
+	InitNetwork(port3, "127.0.0.1", rt3, nodeId3, false, true, chanFile3, chanPin3, fileMap3)
+	nw2 := InitNetwork(port2, "127.0.0.1", rt2, nodeId2, true, true, chanFile2, chanPin2, fileMap2)
 
 	testKademlia := NewKademliaInstance(nw2, nodeId2, ALPHA, K, rt2, chanFile2, fileMap2)
 

--- a/kdmlib/kademlia_lookupalgo_test.go
+++ b/kdmlib/kademlia_lookupalgo_test.go
@@ -35,21 +35,21 @@ func TestKademlia_LookupAlgorithm(t *testing.T) {
 		rt1.GiveOrder(OrderForRoutingTable{ADD, e, false})
 	}
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 2)
 
 	rt2 := CreateAllWorkersForRoutingTable(K, 8, 5, nodeId2)
 	for _, e := range testContacts[0:1] {
 		rt2.GiveOrder(OrderForRoutingTable{ADD, e, false})
 	}
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 2)
 
 	rt3 := CreateAllWorkersForRoutingTable(K, 8, 5, nodeId2)
 	for _, e := range testContacts[11:] {
 		rt3.GiveOrder(OrderForRoutingTable{ADD, e, false})
 	}
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 2)
 
 	chanPin1, chanFile1, fileMap1 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 	chanPin2, chanFile2, fileMap2 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
@@ -65,7 +65,9 @@ func TestKademlia_LookupAlgorithm(t *testing.T) {
 
 	testKademlia.closest = []AddressTriple{}
 	for _, e := range testContacts {
-		testKademlia.closest = append(testKademlia.closest, e)
+		if e.Id != testKademlia.nodeID {
+			testKademlia.closest = append(testKademlia.closest, e)
+		}
 	}
 
 	testKademlia.sortContacts(targetContact.Id)
@@ -107,14 +109,14 @@ func TestKademlia_LookupAlgorithm_160(t *testing.T) {
 		rt1.GiveOrder(OrderForRoutingTable{ADD, e, false})
 	}
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 2)
 
 	rt2 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId2)
 	for _, e := range testContacts[2:7] {
 		rt2.GiveOrder(OrderForRoutingTable{ADD, e, false})
 	}
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 2)
 
 	rt3 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId2)
 	for _, e := range testContacts[2:] {

--- a/kdmlib/kademlia_lookupdata_test.go
+++ b/kdmlib/kademlia_lookupdata_test.go
@@ -4,12 +4,14 @@ import (
 	"Kademlia---P2P-DFS/kdmlib/fileutils"
 	"fmt"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
 )
 
 func TestKademlia_LookupDataFail(t *testing.T) {
+
 	nodeId1 := "10010000"
 	port1 := "12000"
 	nodeId2 := "10110000"
@@ -82,6 +84,7 @@ func TestKademlia_LookupDataFail(t *testing.T) {
 }
 
 func TestKademlia_LookupDataSuccess(t *testing.T) {
+
 	fileName := "11111111"
 	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+fileName, []byte("hello world"), 0644)
 
@@ -90,11 +93,9 @@ func TestKademlia_LookupDataSuccess(t *testing.T) {
 	nodeId2 := "00000100"
 	port2 := "12003"
 
-	targetData := "11111111"
-
 	testContacts := []AddressTriple{
-		{"127.0.0.1", "12003", "00000100"}, {"127.0.0.1", "12001", "00000001"},
-		{"127.0.0.1", "12002", "00000011"}, {"127.0.0.1", "12000", "10010000"},
+		{"127.0.0.1", "12003", "00000100"},
+		{"127.0.0.1", "12002", "00000011"},
 		{"127.0.0.1", "12004", "01100000"}, {"127.0.0.1", "12005", "11110000"},
 		{"127.0.0.1", "12006", "11010000"}, {"127.0.0.1", "12007", "11111101"},
 		{"127.0.0.1", "12008", "01110000"}, {"127.0.0.1", "12009", "11110001"},
@@ -103,7 +104,7 @@ func TestKademlia_LookupDataSuccess(t *testing.T) {
 		{"127.0.0.1", "12014", "11110110"}, {"127.0.0.1", "12015", "11110111"},
 		{"127.0.0.1", "12016", "11111000"}, {"127.0.0.1", "12017", "11111001"},
 		{"127.0.0.1", "12018", "11111010"}, {"127.0.0.1", "12019", "11111011"},
-		{"127.0.0.1", "12020", "11111100"}, {"127.0.0.1", "13000", "10110000"}}
+		{"127.0.0.1", "12020", "11111100"}}
 
 	rt1 := CreateAllWorkersForRoutingTable(K, 8, 5, nodeId1)
 	for _, e := range testContacts[0:11] {
@@ -127,7 +128,7 @@ func TestKademlia_LookupDataSuccess(t *testing.T) {
 
 	testKademlia := NewKademliaInstance(nw2, nodeId2, ALPHA, K, rt2, chanFile2, fileMap2)
 
-	dataReturn := testKademlia.LookupData(targetData)
+	dataReturn := testKademlia.LookupData(fileName)
 
 	fmt.Println("Data returned: ", string(dataReturn))
 
@@ -135,6 +136,53 @@ func TestKademlia_LookupDataSuccess(t *testing.T) {
 		t.Error("Expected to get data back...")
 		t.Fail()
 	}
+
+	os.Remove(fileUtilsKademlia.FileDirectory + fileName)
+}
+
+func TestKademlia_LookupData_160(t *testing.T) {
+
+	fileName := "1011000010000101111101010010000000001011110101000000001000101001001111010110111001001010001000110110001110001010001000010011001100011001010000001110110011010011"
+	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+fileName, []byte("hello world"), 0644)
+
+	time.Sleep(time.Second * 2)
+
+	testContacts := []AddressTriple{
+		{"127.0.0.1", "22000", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "22001", GenerateRandID(int64(rand.Intn(100)), 160)},
+		{"127.0.0.1", "22002", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "22003", GenerateRandID(int64(rand.Intn(100)), 160)},
+		{"127.0.0.1", "22004", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "22005", GenerateRandID(int64(rand.Intn(100)), 160)},
+		{"127.0.0.1", "22006", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "22007", GenerateRandID(int64(rand.Intn(100)), 160)}}
+
+	nodeId1 := testContacts[0].Id
+	port1 := testContacts[0].Port
+	nodeId2 := testContacts[5].Id
+	port2 := testContacts[5].Port
+
+	rt1 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId1)
+	for _, e := range testContacts[1:8] {
+		rt1.GiveOrder(OrderForRoutingTable{ADD, e, false})
+	}
+
+	time.Sleep(time.Second * 1)
+
+	rt2 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId2)
+	for _, e := range testContacts[2:7] {
+		rt2.GiveOrder(OrderForRoutingTable{ADD, e, false})
+	}
+
+	time.Sleep(time.Second * 1)
+
+	chanPin1, chanFile1, fileMap1 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
+	chanPin2, chanFile2, fileMap2 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
+
+	nw1 := InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, true, chanFile1, chanPin1, fileMap1)
+	InitNetwork(port2, "127.0.0.1", rt2, nodeId2, false, true, chanFile2, chanPin2, fileMap2)
+
+	testKademlia := NewKademliaInstance(nw1, nodeId1, ALPHA, K, rt1, chanFile1, fileMap1)
+
+	dataReturn := testKademlia.LookupData(fileName)
+
+	fmt.Println("Data returned: ", string(dataReturn))
 
 	os.Remove(fileUtilsKademlia.FileDirectory + fileName)
 }

--- a/kdmlib/kademlia_lookupdata_test.go
+++ b/kdmlib/kademlia_lookupdata_test.go
@@ -86,7 +86,7 @@ func TestKademlia_LookupDataFail(t *testing.T) {
 func TestKademlia_LookupDataSuccess(t *testing.T) {
 
 	fileName := "11111111"
-	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+fileName, []byte("hello world"), 0644)
+	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+ConvertToHexAddr(fileName), []byte("hello world"), 0644)
 
 	nodeId1 := "11111001"
 	port1 := "12017"
@@ -141,13 +141,13 @@ func TestKademlia_LookupDataSuccess(t *testing.T) {
 		t.Fail()
 	}
 
-	os.Remove(fileUtilsKademlia.FileDirectory + fileName)
+	os.Remove(fileUtilsKademlia.FileDirectory + ConvertToHexAddr(fileName))
 }
 
 func TestKademlia_LookupData_160(t *testing.T) {
 
 	fileName := "1011000010000101111101010010000000001011110101000000001000101001001111010110111001001010001000110110001110001010001000010011001100011001010000001110110011010011"
-	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+fileName, []byte("hello world"), 0644)
+	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+ConvertToHexAddr(fileName), []byte("hello world"), 0644)
 
 	time.Sleep(time.Second * 2)
 
@@ -167,14 +167,14 @@ func TestKademlia_LookupData_160(t *testing.T) {
 		rt1.GiveOrder(OrderForRoutingTable{ADD, e, false})
 	}
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 2)
 
 	rt2 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId2)
 	for _, e := range testContacts[2:7] {
 		rt2.GiveOrder(OrderForRoutingTable{ADD, e, false})
 	}
 
-	time.Sleep(time.Second * 1)
+	time.Sleep(time.Second * 2)
 
 	chanPin1, chanFile1, fileMap1 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 	chanPin2, chanFile2, fileMap2 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
@@ -193,5 +193,5 @@ func TestKademlia_LookupData_160(t *testing.T) {
 		t.Fail()
 	}
 
-	os.Remove(fileUtilsKademlia.FileDirectory + fileName)
+	os.Remove(fileUtilsKademlia.FileDirectory + ConvertToHexAddr(fileName))
 }

--- a/kdmlib/kademlia_lookupdata_test.go
+++ b/kdmlib/kademlia_lookupdata_test.go
@@ -56,9 +56,9 @@ func TestKademlia_LookupDataFail(t *testing.T) {
 	chanPin2, chanFile2, fileMap2 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 	chanPin3, chanFile3, fileMap3 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 
-	InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, chanFile1, chanPin1, fileMap1)
-	InitNetwork(port3, "127.0.0.1", rt3, nodeId3, false, chanFile3, chanPin3, fileMap3)
-	nw2 := InitNetwork(port2, "127.0.0.1", rt2, nodeId2, true, chanFile2, chanPin2, fileMap2)
+	InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, true, chanFile1, chanPin1, fileMap1)
+	InitNetwork(port3, "127.0.0.1", rt3, nodeId3, false, true, chanFile3, chanPin3, fileMap3)
+	nw2 := InitNetwork(port2, "127.0.0.1", rt2, nodeId2, true, true, chanFile2, chanPin2, fileMap2)
 
 	testKademlia := NewKademliaInstance(nw2, nodeId2, ALPHA, K, rt2, chanFile2, fileMap2)
 
@@ -122,8 +122,8 @@ func TestKademlia_LookupDataSuccess(t *testing.T) {
 	chanPin1, chanFile1, fileMap1 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 	chanPin2, chanFile2, fileMap2 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 
-	InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, chanFile1, chanPin1, fileMap1)
-	nw2 := InitNetwork(port2, "127.0.0.1", rt2, nodeId2, true, chanFile2, chanPin2, fileMap2)
+	InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, true, chanFile1, chanPin1, fileMap1)
+	nw2 := InitNetwork(port2, "127.0.0.1", rt2, nodeId2, true, true, chanFile2, chanPin2, fileMap2)
 
 	testKademlia := NewKademliaInstance(nw2, nodeId2, ALPHA, K, rt2, chanFile2, fileMap2)
 

--- a/kdmlib/kademlia_lookupdata_test.go
+++ b/kdmlib/kademlia_lookupdata_test.go
@@ -88,14 +88,13 @@ func TestKademlia_LookupDataSuccess(t *testing.T) {
 	fileName := "11111111"
 	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+fileName, []byte("hello world"), 0644)
 
-	nodeId1 := "00000011"
-	port1 := "12002"
+	nodeId1 := "11111001"
+	port1 := "12017"
 	nodeId2 := "00000100"
 	port2 := "12003"
 
 	testContacts := []AddressTriple{
-		{"127.0.0.1", "12003", "00000100"},
-		{"127.0.0.1", "12002", "00000011"},
+		{"127.0.0.1", "12003", "00000100"}, {"127.0.0.1", "12002", "00000011"},
 		{"127.0.0.1", "12004", "01100000"}, {"127.0.0.1", "12005", "11110000"},
 		{"127.0.0.1", "12006", "11010000"}, {"127.0.0.1", "12007", "11111101"},
 		{"127.0.0.1", "12008", "01110000"}, {"127.0.0.1", "12009", "11110001"},
@@ -114,7 +113,7 @@ func TestKademlia_LookupDataSuccess(t *testing.T) {
 	time.Sleep(time.Second * 1)
 
 	rt2 := CreateAllWorkersForRoutingTable(K, 8, 5, nodeId2)
-	for _, e := range testContacts[1:9] {
+	for _, e := range testContacts[1:] {
 		rt2.GiveOrder(OrderForRoutingTable{ADD, e, false})
 	}
 
@@ -134,6 +133,11 @@ func TestKademlia_LookupDataSuccess(t *testing.T) {
 
 	if dataReturn == nil {
 		t.Error("Expected to get data back...")
+		t.Fail()
+	}
+
+	if string(dataReturn) != "hello world" {
+		t.Error("Expected to get data back 'hello world, got", string(dataReturn))
 		t.Fail()
 	}
 
@@ -183,6 +187,11 @@ func TestKademlia_LookupData_160(t *testing.T) {
 	dataReturn := testKademlia.LookupData(fileName)
 
 	fmt.Println("Data returned: ", string(dataReturn))
+
+	if string(dataReturn) != "hello world" {
+		t.Error("Expected to get data back 'hello world, got", string(dataReturn))
+		t.Fail()
+	}
 
 	os.Remove(fileUtilsKademlia.FileDirectory + fileName)
 }

--- a/kdmlib/kademlia_store_test.go
+++ b/kdmlib/kademlia_store_test.go
@@ -9,7 +9,6 @@ import (
 )
 
 func TestKademlia_StoreData(t *testing.T) {
-
 	fileName := "11111111"
 
 	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+fileName, []byte("hello world"), 0644)

--- a/kdmlib/kademlia_store_test.go
+++ b/kdmlib/kademlia_store_test.go
@@ -3,6 +3,7 @@ package kdmlib
 import (
 	"Kademlia---P2P-DFS/kdmlib/fileutils"
 	"io/ioutil"
+	"math/rand"
 	"os"
 	"testing"
 	"time"
@@ -11,7 +12,7 @@ import (
 func TestKademlia_StoreData(t *testing.T) {
 	fileName := "11111111"
 
-	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+fileName, []byte("hello world"), 0644)
+	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+ConvertToHexAddr(fileName), []byte("hello world"), 0644)
 
 	nodeId1 := "10010000"
 	port1 := "12000"
@@ -79,23 +80,97 @@ func TestKademlia_StoreData(t *testing.T) {
 
 	time.Sleep(time.Second * 1)
 
-	data := fileUtilsKademlia.ReadFileFromOS("1001000011111111")
+	data := fileUtilsKademlia.ReadFileFromOS(ConvertToHexAddr(nodeId1 + fileName))
 
 	if string(data) != "hello world" {
 		t.Error("File was not uploaded")
 		t.Fail()
 	} else {
-		os.Remove(fileUtilsKademlia.FileDirectory + "1001000011111111")
+		os.Remove(fileUtilsKademlia.FileDirectory + ConvertToHexAddr(nodeId1+fileName))
 	}
 
-	data = fileUtilsKademlia.ReadFileFromOS("1111010011111111")
+	data = fileUtilsKademlia.ReadFileFromOS(ConvertToHexAddr(nodeId4 + fileName))
 
 	if string(data) != "hello world" {
 		t.Error("File was not uploaded")
 		t.Fail()
 	} else {
-		os.Remove(fileUtilsKademlia.FileDirectory + "1111010011111111")
+		os.Remove(fileUtilsKademlia.FileDirectory + ConvertToHexAddr(nodeId4+fileName))
 	}
 
-	os.Remove(fileUtilsKademlia.FileDirectory + "11111111")
+	os.Remove(fileUtilsKademlia.FileDirectory + ConvertToHexAddr(fileName))
+}
+
+func TestKademlia_StoreData_160(t *testing.T) {
+	fileName := "1101011011110000010110101111010011010100001000010110001011000010010100111011111001001100000010101111000101101010111100110000000010110001001000110010110011000111"
+
+	ioutil.WriteFile(fileUtilsKademlia.FileDirectory+ConvertToHexAddr(fileName), []byte("hello world"), 0644)
+
+	testContacts := []AddressTriple{
+		{"127.0.0.1", "24000", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "24001", GenerateRandID(int64(rand.Intn(100)), 160)},
+		{"127.0.0.1", "24002", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "24003", GenerateRandID(int64(rand.Intn(100)), 160)},
+		{"127.0.0.1", "24004", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "24005", GenerateRandID(int64(rand.Intn(100)), 160)},
+		{"127.0.0.1", "24006", GenerateRandID(int64(rand.Intn(100)), 160)}, {"127.0.0.1", "24007", GenerateRandID(int64(rand.Intn(100)), 160)}}
+
+	nodeId1 := testContacts[0].Id
+	port1 := testContacts[0].Port
+	nodeId2 := testContacts[3].Id
+	port2 := testContacts[3].Port
+	nodeId3 := testContacts[5].Id
+	port3 := testContacts[5].Port
+
+	rt1 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId1)
+	for _, e := range testContacts[1:] {
+		rt1.GiveOrder(OrderForRoutingTable{ADD, e, false})
+	}
+
+	time.Sleep(time.Second * 2)
+
+	rt2 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId2)
+	for _, e := range testContacts[2:6] {
+		rt2.GiveOrder(OrderForRoutingTable{ADD, e, false})
+	}
+
+	time.Sleep(time.Second * 2)
+
+	rt3 := CreateAllWorkersForRoutingTable(K, 160, 5, nodeId3)
+	for _, e := range testContacts[0:3] {
+		rt3.GiveOrder(OrderForRoutingTable{ADD, e, false})
+	}
+
+	time.Sleep(time.Second * 2)
+
+	chanPin1, chanFile1, fileMap1 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
+	chanPin2, chanFile2, fileMap2 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
+	chanPin3, chanFile3, fileMap3 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
+
+	nw1 := InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, true, chanFile1, chanPin1, fileMap1)
+	InitNetwork(port2, "127.0.0.1", rt2, nodeId2, false, true, chanFile2, chanPin2, fileMap2)
+	InitNetwork(port3, "127.0.0.1", rt3, nodeId3, false, true, chanFile3, chanPin3, fileMap3)
+
+	testKademlia := NewKademliaInstance(nw1, nodeId1, ALPHA, K, rt1, chanFile1, fileMap1)
+
+	testKademlia.StoreData(fileName)
+
+	time.Sleep(time.Second * 1)
+
+	data := fileUtilsKademlia.ReadFileFromOS(ConvertToHexAddr(nodeId2 + fileName))
+
+	if string(data) != "hello world" {
+		t.Error("File was not uploaded")
+		t.Fail()
+	} else {
+		os.Remove(fileUtilsKademlia.FileDirectory + ConvertToHexAddr(nodeId2+fileName))
+	}
+
+	data = fileUtilsKademlia.ReadFileFromOS(ConvertToHexAddr(nodeId3 + fileName))
+
+	if string(data) != "hello world" {
+		t.Error("File was not uploaded")
+		t.Fail()
+	} else {
+		os.Remove(fileUtilsKademlia.FileDirectory + ConvertToHexAddr(nodeId3+fileName))
+	}
+
+	os.Remove(fileUtilsKademlia.FileDirectory + ConvertToHexAddr(fileName))
 }

--- a/kdmlib/kademlia_store_test.go
+++ b/kdmlib/kademlia_store_test.go
@@ -69,10 +69,10 @@ func TestKademlia_StoreData(t *testing.T) {
 	chanPin3, chanFile3, fileMap3 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 	chanPin4, chanFile4, fileMap4 := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 
-	InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, chanFile1, chanPin1, fileMap1)
-	InitNetwork(port3, "127.0.0.1", rt3, nodeId3, false, chanFile3, chanPin3, fileMap3)
-	InitNetwork(port4, "127.0.0.1", rt4, nodeId4, false, chanFile4, chanPin4, fileMap4)
-	nw2 := InitNetwork(port2, "127.0.0.1", rt2, nodeId2, false, chanFile2, chanPin2, fileMap2)
+	InitNetwork(port1, "127.0.0.1", rt1, nodeId1, false, true, chanFile1, chanPin1, fileMap1)
+	InitNetwork(port3, "127.0.0.1", rt3, nodeId3, false, true, chanFile3, chanPin3, fileMap3)
+	InitNetwork(port4, "127.0.0.1", rt4, nodeId4, false, true, chanFile4, chanPin4, fileMap4)
+	nw2 := InitNetwork(port2, "127.0.0.1", rt2, nodeId2, false, true, chanFile2, chanPin2, fileMap2)
 
 	testKademlia := NewKademliaInstance(nw2, nodeId2, ALPHA, K, rt2, chanFile2, fileMap2)
 

--- a/kdmlib/kademlia_test.go
+++ b/kdmlib/kademlia_test.go
@@ -11,7 +11,7 @@ func TestKademlia_SortContacts(t *testing.T) {
 	nodeId := "11100000"
 	rt := CreateAllWorkersForRoutingTable(K, IDLENGTH, 5, nodeId)
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
-	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, chanFile, chanPin, fileMap)
+	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, true, chanFile, chanPin, fileMap)
 	testKademlia := NewKademliaInstance(nw, nodeId, ALPHA, K, rt, chanFile, fileMap)
 
 	target := "11111111"
@@ -57,7 +57,7 @@ func TestKademlia_RefreshClosest(t *testing.T) {
 	nodeId := "11100000"
 	rt := CreateAllWorkersForRoutingTable(K, IDLENGTH, 5, nodeId)
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
-	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, chanFile, chanPin, fileMap)
+	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, true, chanFile, chanPin, fileMap)
 	testKademlia := NewKademliaInstance(nw, nodeId, ALPHA, K, rt, chanFile, fileMap)
 
 	target := "11111111"
@@ -110,7 +110,7 @@ func TestKademlia_GetNextContact_AskedAllContacts(t *testing.T) {
 	nodeId := "11100000"
 	rt := CreateAllWorkersForRoutingTable(K, IDLENGTH, 5, nodeId)
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
-	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, chanFile, chanPin, fileMap)
+	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, true, chanFile, chanPin, fileMap)
 	testKademlia := NewKademliaInstance(nw, nodeId, ALPHA, K, rt, chanFile, fileMap)
 
 	t1 := AddressTriple{"t1", "00", "10010000"}
@@ -176,7 +176,7 @@ func TestKademlia_LookupContactTimeout(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
-	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, chanFile, chanPin, fileMap)
+	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, true, chanFile, chanPin, fileMap)
 	testKademlia := NewKademliaInstance(nw, nodeId, ALPHA, K, rt, chanFile, fileMap)
 
 	contacts, contactWithData := testKademlia.LookupAlgorithm(targetContact.Id, ContactLookup)
@@ -215,7 +215,7 @@ func TestKademlia_LookupDataTimeout(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
-	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, chanFile, chanPin, fileMap)
+	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, true, chanFile, chanPin, fileMap)
 	testKademlia := NewKademliaInstance(nw, nodeId, ALPHA, K, rt, chanFile, fileMap)
 
 	dataReturned := testKademlia.LookupData(targetData)
@@ -242,7 +242,7 @@ func TestKademlia_LookupEmptyRT(t *testing.T) {
 	time.Sleep(time.Second * 2)
 
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
-	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, chanFile, chanPin, fileMap)
+	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, true, chanFile, chanPin, fileMap)
 	testKademlia := NewKademliaInstance(nw, nodeId, ALPHA, K, rt, chanFile, fileMap)
 
 	contacts, contactWithData := testKademlia.LookupAlgorithm(targetContact.Id, ContactLookup)

--- a/kdmlib/kademlia_test.go
+++ b/kdmlib/kademlia_test.go
@@ -9,7 +9,7 @@ import (
 
 func TestKademlia_SortContacts(t *testing.T) {
 	nodeId := "11100000"
-	rt := CreateAllWorkersForRoutingTable(K, IDLENGTH, 5, nodeId)
+	rt := CreateAllWorkersForRoutingTable(K, 8, 5, nodeId)
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, true, chanFile, chanPin, fileMap)
 	testKademlia := NewKademliaInstance(nw, nodeId, ALPHA, K, rt, chanFile, fileMap)
@@ -55,7 +55,7 @@ func TestKademlia_SortContacts(t *testing.T) {
 
 func TestKademlia_RefreshClosest(t *testing.T) {
 	nodeId := "11100000"
-	rt := CreateAllWorkersForRoutingTable(K, IDLENGTH, 5, nodeId)
+	rt := CreateAllWorkersForRoutingTable(K, 8, 5, nodeId)
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, true, chanFile, chanPin, fileMap)
 	testKademlia := NewKademliaInstance(nw, nodeId, ALPHA, K, rt, chanFile, fileMap)
@@ -108,7 +108,7 @@ func TestKademlia_RefreshClosest(t *testing.T) {
 
 func TestKademlia_GetNextContact_AskedAllContacts(t *testing.T) {
 	nodeId := "11100000"
-	rt := CreateAllWorkersForRoutingTable(K, IDLENGTH, 5, nodeId)
+	rt := CreateAllWorkersForRoutingTable(K, 8, 5, nodeId)
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 	nw := InitNetwork("12000", "127.0.0.1", rt, nodeId, true, true, chanFile, chanPin, fileMap)
 	testKademlia := NewKademliaInstance(nw, nodeId, ALPHA, K, rt, chanFile, fileMap)

--- a/kdmlib/network.go
+++ b/kdmlib/network.go
@@ -314,6 +314,7 @@ func (network *Network) SendFindData(toContact AddressTriple, targetID string) (
 	proto.Unmarshal(answer, object)
 
 	if object.REQUEST_ID == FindContact {
+		fmt.Println("Contact: '" + ConvertToHexAddr(object.ID) + "' is sending back CONTACTS!")
 		result := make([]AddressTriple, len(object.GetReturnContacts().ContactInfo))
 		for i := 0; i < len(object.GetReturnContacts().ContactInfo); i++ {
 			result[i] = AddressTriple{object.GetReturnContacts().ContactInfo[i].IP, object.GetReturnContacts().ContactInfo[i].PORT, object.GetReturnContacts().ContactInfo[i].ID}
@@ -321,6 +322,7 @@ func (network *Network) SendFindData(toContact AddressTriple, targetID string) (
 		return AddressTriple{}, result, err
 
 	} else if object.REQUEST_ID == FindData {
+		fmt.Println("Contact: '" + ConvertToHexAddr(object.ID) + "' is sending back its SIGNATURE!")
 		return toContact, nil, err
 	}
 

--- a/kdmlib/network.go
+++ b/kdmlib/network.go
@@ -154,7 +154,7 @@ func (network *Network) TCPConnectionWorker() {
 func sendFileTCP(conn net.Conn, fileName string) {
 	defer conn.Close()
 
-	file := fileUtilsKademlia.ReadFileFromOS(fileName)
+	file := fileUtilsKademlia.ReadFileFromOS(ConvertToHexAddr(fileName))
 	if file != nil {
 		conn.Write(file)
 	}
@@ -200,13 +200,13 @@ func (network *Network) handleStore(fileName string, callbackContact AddressTrip
 		if network.fileTest {
 			fileName = network.nodeID + fileName
 		}
-		network.fileChannel <- fileUtilsKademlia.Order{Action: fileUtilsKademlia.ADD, Name: fileName, Content: data}
+		network.fileChannel <- fileUtilsKademlia.Order{Action: fileUtilsKademlia.ADD, Name: ConvertToHexAddr(fileName), Content: data}
 	}
 }
 
 //Check if data is present and returns it if it is. Returns a list of contacts if not present.
 func (network *Network) handleFindData(DataID string) *pb.Container {
-	if network.fileMap.IsPresent(DataID) {
+	if network.fileMap.IsPresent(ConvertToHexAddr(DataID)) {
 		Container := &pb.Container{REQUEST_TYPE: Return, REQUEST_ID: FindData, MSG_ID: "", ID: network.nodeID, Attachment: nil}
 		return Container
 	} else {
@@ -314,7 +314,6 @@ func (network *Network) SendFindData(toContact AddressTriple, targetID string) (
 	proto.Unmarshal(answer, object)
 
 	if object.REQUEST_ID == FindContact {
-		fmt.Println("Contact: '" + ConvertToHexAddr(object.ID) + "' is sending back CONTACTS!")
 		result := make([]AddressTriple, len(object.GetReturnContacts().ContactInfo))
 		for i := 0; i < len(object.GetReturnContacts().ContactInfo); i++ {
 			result[i] = AddressTriple{object.GetReturnContacts().ContactInfo[i].IP, object.GetReturnContacts().ContactInfo[i].PORT, object.GetReturnContacts().ContactInfo[i].ID}
@@ -322,7 +321,6 @@ func (network *Network) SendFindData(toContact AddressTriple, targetID string) (
 		return AddressTriple{}, result, err
 
 	} else if object.REQUEST_ID == FindData {
-		fmt.Println("Contact: '" + ConvertToHexAddr(object.ID) + "' is sending back its SIGNATURE!")
 		return toContact, nil, err
 	}
 
@@ -331,7 +329,7 @@ func (network *Network) SendFindData(toContact AddressTriple, targetID string) (
 
 //Request a file via TCP.
 func (network *Network) RequestFile(toContact AddressTriple, fileName string) []byte {
-	fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' is requesting file " + fileName + " from node '" + ConvertToHexAddr(toContact.Id) + "' via TCP")
+	fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' is requesting file '" + ConvertToHexAddr(fileName) + "' from node '" + ConvertToHexAddr(toContact.Id) + "' via TCP")
 	conn, err := net.Dial("tcp", toContact.Ip+":"+toContact.Port)
 	if err != nil {
 		panic(err)

--- a/kdmlib/network.go
+++ b/kdmlib/network.go
@@ -89,6 +89,7 @@ type udpPacketAndInfo struct {
 
 //Launch the UDP server on port "port", with the specified amount of workers.
 func (network *Network) UDPServer(numberOfWorkers int, buffer []byte) {
+	fmt.Println("UDP connection initiated for node '" + ConvertToHexAddr(network.nodeID) + "' on " + network.ip + ":" + network.port)
 
 	for i := 0; i < numberOfWorkers; i++ {
 		go network.UDPConnectionWorker()
@@ -120,6 +121,7 @@ type tcpPacketAndInfo struct {
 
 //Launch the TCP server on port "port", with the specified amount of workers.
 func (network *Network) TCPServer(numberOfWorkers int, buffer []byte) {
+	fmt.Println("TCP connection initiated for node '" + ConvertToHexAddr(network.nodeID) + "' on " + network.ip + ":" + network.port)
 
 	for i := 0; i < numberOfWorkers; i++ {
 		go network.TCPConnectionWorker()
@@ -133,8 +135,6 @@ func (network *Network) TCPServer(numberOfWorkers int, buffer []byte) {
 			fmt.Println("Error: ", err)
 			os.Exit(1)
 		}
-		fmt.Println("Client connected")
-
 		network.tcpPacketsChan <- tcpPacketAndInfo{connection: conn, packet: buffer}
 	}
 }
@@ -156,9 +156,7 @@ func sendFileTCP(conn net.Conn, fileName string) {
 
 	file := fileUtilsKademlia.ReadFileFromOS(fileName)
 	if file != nil {
-		if len(file) < FILESIZELIMIT {
-			conn.Write(file)
-		}
+		conn.Write(file)
 	}
 }
 
@@ -166,9 +164,11 @@ func sendFileTCP(conn net.Conn, fileName string) {
 func (network *Network) requestHandler(container *pb.Container, addr net.Addr) {
 	switch container.REQUEST_ID {
 	case Ping:
+		fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' received a PING RPC from node '" + ConvertToHexAddr(container.ID) + "'")
 		network.udpConn.WriteTo([]byte("pong"), addr)
 		break
 	case FindContact:
+		fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' received a FIND_NODE RPC from node '" + ConvertToHexAddr(container.ID) + "'")
 		packet, err := proto.Marshal(network.handleFindContact(container.GetRequestContact().ID))
 		if err == nil {
 			network.udpConn.WriteTo(packet, addr)
@@ -177,6 +177,7 @@ func (network *Network) requestHandler(container *pb.Container, addr net.Addr) {
 		}
 		break
 	case FindData:
+		fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' received a FIND_DATA RPC from node '" + ConvertToHexAddr(container.ID) + "'")
 		packet, err := proto.Marshal(network.handleFindData(container.GetRequestData().KEY))
 		if err == nil {
 			network.udpConn.WriteTo(packet, addr)
@@ -184,6 +185,7 @@ func (network *Network) requestHandler(container *pb.Container, addr net.Addr) {
 			fmt.Println("something went wrong")
 		}
 	case Store:
+		fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' received a STORE RPC from node '" + ConvertToHexAddr(container.ID) + "'")
 		network.handleStore(container.GetRequestStore().KEY, AddressTriple{addr.(*net.UDPAddr).IP.String(), container.PORT, container.ID})
 		network.udpConn.WriteTo([]byte("stored"), addr)
 	}
@@ -250,7 +252,8 @@ func sendPacket(ip string, port string, packet []byte) ([]byte, error) {
 
 //Send STORE request.
 func (network *Network) SendStore(toContact AddressTriple, fileName string) (string, error) {
-	msgID := GenerateRandID(int64(rand.Intn(100)))
+	fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' is sending a STORE RPC to node '" + ConvertToHexAddr(toContact.Id) + "'")
+	msgID := GenerateRandID(int64(rand.Intn(100)), 160)
 	Info := &pb.REQUEST_STORE{KEY: fileName, VALUE: nil}
 	Data := &pb.Container_RequestStore{RequestStore: Info}
 	Container := &pb.Container{REQUEST_TYPE: Request, REQUEST_ID: Store, MSG_ID: msgID, ID: network.nodeID, Attachment: Data, PORT: network.port}
@@ -266,7 +269,8 @@ func (network *Network) SendStore(toContact AddressTriple, fileName string) (str
 
 //Send FIND_NODE request, return an AddressTriple slice.
 func (network *Network) SendFindNode(toContact AddressTriple, targetID string) ([]AddressTriple, error) {
-	msgID := GenerateRandID(int64(rand.Intn(100)))
+	fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' is sending a FIND_NODE RPC to node '" + ConvertToHexAddr(toContact.Id) + "'")
+	msgID := GenerateRandID(int64(rand.Intn(100)), 160)
 	Info := &pb.REQUEST_CONTACT{ID: targetID}
 	Data := &pb.Container_RequestContact{RequestContact: Info}
 	Container := &pb.Container{REQUEST_TYPE: Request, REQUEST_ID: FindContact, MSG_ID: msgID, ID: network.nodeID, PORT: network.port, Attachment: Data}
@@ -292,7 +296,8 @@ func (network *Network) SendFindNode(toContact AddressTriple, targetID string) (
 //If data is found, it's details are returned in a AddressTriple, which can later be used to fetch file via TCP.
 //If data is not located, a slice of AddressTriples is returned, containing closest contacts (equal to the result of a FIND_NODE RPC).
 func (network *Network) SendFindData(toContact AddressTriple, targetID string) (AddressTriple, []AddressTriple, error) {
-	msgID := GenerateRandID(int64(rand.Intn(100)))
+	fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' is sending a FIND_DATA RPC to node '" + ConvertToHexAddr(toContact.Id) + "'")
+	msgID := GenerateRandID(int64(rand.Intn(100)), 160)
 	Info := &pb.REQUEST_DATA{KEY: targetID}
 	Data := &pb.Container_RequestData{RequestData: Info}
 	Container := &pb.Container{REQUEST_TYPE: Request, REQUEST_ID: FindData, MSG_ID: msgID, ID: network.nodeID, Attachment: Data, PORT: network.port}
@@ -316,7 +321,6 @@ func (network *Network) SendFindData(toContact AddressTriple, targetID string) (
 		return AddressTriple{}, result, err
 
 	} else if object.REQUEST_ID == FindData {
-		fmt.Println("I have the data!", toContact)
 		return toContact, nil, err
 	}
 
@@ -325,6 +329,7 @@ func (network *Network) SendFindData(toContact AddressTriple, targetID string) (
 
 //Request a file via TCP.
 func (network *Network) RequestFile(toContact AddressTriple, fileName string) []byte {
+	fmt.Println("Node '" + ConvertToHexAddr(network.nodeID) + "' is requesting file " + fileName + " from node '" + ConvertToHexAddr(toContact.Id) + "' via TCP")
 	conn, err := net.Dial("tcp", toContact.Ip+":"+toContact.Port)
 	if err != nil {
 		panic(err)

--- a/kdmlib/routingtable.go
+++ b/kdmlib/routingtable.go
@@ -226,7 +226,7 @@ func ping(address AddressTriple) error {
 	}
 	defer conn.Close()
 
-	msgID := GenerateRandID(int64(rand.Intn(100)))
+	msgID := GenerateRandID(int64(rand.Intn(100)), 160)
 	Info := &pb.REQUEST_PING{ID: "asdasd"}
 	Data := &pb.Container_RequestPing{RequestPing: Info}
 	Container := &pb.Container{REQUEST_TYPE: Request, REQUEST_ID: Ping, MSG_ID: msgID, Attachment: Data}

--- a/kdmlib/routingtable.go
+++ b/kdmlib/routingtable.go
@@ -200,7 +200,7 @@ func sendToPinger(routingTable routingTableAndCache, index int, order OrderForRo
 func bumpElement(routingTable routingTableAndCache, index int, order OrderForRoutingTable) {
 	for ele := (*(routingTable.routingTable))[index].Front(); ele != nil; ele = ele.Next() {
 		if ele.Value.(AddressTriple).Id == order.Target.Id {
-			fmt.Println("already present so pushing this value")
+			//fmt.Println("already present so pushing this value")
 			(*(routingTable.routingTable))[index].MoveToFront(ele)
 			break
 		}

--- a/kdmlib/utils.go
+++ b/kdmlib/utils.go
@@ -110,6 +110,14 @@ func GenerateIDFromHex(hexAddr string) string {
 	return binAddr
 }
 
+func GenerateZeroID(binLength int) string {
+	zeroString := ""
+	for i := 0; i < binLength; i++ {
+		zeroString += "0"
+	}
+	return zeroString
+}
+
 //Encodes a file name into a 160 bit ID
 //Maximum 19 characters is allowed in fileName.
 func HashKademliaID(fileName string) string {
@@ -198,4 +206,11 @@ func SendGetRequest(triple AddressTriple, name string) []byte {
 		}
 	}
 	return nil
+}
+
+func PrintListOfContacts(description string, contactList []AddressTriple) {
+	fmt.Println(description)
+	for index := range contactList {
+		fmt.Println("['"+ConvertToHexAddr(contactList[index].Id)+"'", contactList[index].Ip+":"+contactList[index].Port+"]")
+	}
 }

--- a/kdmlib/utils.go
+++ b/kdmlib/utils.go
@@ -1,16 +1,12 @@
 package kdmlib
 
 import (
-	"bytes"
-	"encoding/hex"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"math"
 	"math/rand"
 	"net"
-	"net/http"
 	"strconv"
 	"strings"
 	"time"
@@ -120,6 +116,7 @@ func GenerateZeroID(binLength int) string {
 
 //Encodes a file name into a 160 bit ID
 //Maximum 19 characters is allowed in fileName.
+/*
 func HashKademliaID(fileName string) string {
 	f := hex.EncodeToString([]byte(fileName))
 	if len(f) > 38 {
@@ -131,6 +128,7 @@ func HashKademliaID(fileName string) string {
 	}
 	return f
 }
+*/
 
 func ComputeDistance(id1 string, id2 string) (string, error) {
 	if len(id1) != len(id2) {
@@ -167,6 +165,37 @@ func AlreadyAsked(asked []AddressTriple, c AddressTriple) bool {
 	}
 	return false
 }
+
+func PrintListOfContacts(description string, contactList []AddressTriple) {
+	fmt.Println(description)
+	for index := range contactList {
+		fmt.Println("['"+ConvertToHexAddr(contactList[index].Id)+"'", contactList[index].Ip+":"+contactList[index].Port+"]")
+	}
+}
+
+func IsResultClosed(ch <-chan interface{}) bool {
+	select {
+
+	case <-ch:
+		return true
+	default:
+	}
+
+	return false
+}
+
+func IsLookupClosed(ch <-chan LookupOrder) bool {
+	select {
+
+	case <-ch:
+		return true
+	default:
+	}
+
+	return false
+}
+
+/*
 
 func SendPostRequest(triple AddressTriple, content []byte) string {
 	req, err := http.NewRequest("POST", "http://"+triple.Ip+":8000/?fromNetwork=true", bytes.NewBuffer(content))
@@ -208,9 +237,4 @@ func SendGetRequest(triple AddressTriple, name string) []byte {
 	return nil
 }
 
-func PrintListOfContacts(description string, contactList []AddressTriple) {
-	fmt.Println(description)
-	for index := range contactList {
-		fmt.Println("['"+ConvertToHexAddr(contactList[index].Id)+"'", contactList[index].Ip+":"+contactList[index].Port+"]")
-	}
-}
+*/

--- a/kdmlib/utils.go
+++ b/kdmlib/utils.go
@@ -17,18 +17,16 @@ import (
 )
 
 const (
-	K             = 20
-	ALPHA         = 3
-	IDLENGTH      = 160
-	FILESIZELIMIT = 10000000000
+	K     = 20
+	ALPHA = 3
 )
 
 //Generates a Random ID, of specified length, given by constant IDLENGTH
 //The returned ID is a bitwise representation
-func GenerateRandID(seed int64) string {
+func GenerateRandID(seed int64, binLength int) string {
 	id := ""
 	rand.Seed(time.Now().UnixNano() - seed)
-	for i := 0; i < IDLENGTH; i++ {
+	for i := 0; i < binLength; i++ {
 		id += strconv.Itoa(rand.Intn(2))
 	}
 
@@ -38,7 +36,7 @@ func GenerateRandID(seed int64) string {
 //Converts a bitwise-represented ID into a HEX-represented ID
 func ConvertToHexAddr(binAddr string) string {
 	hexAddr := ""
-	for i := 0; i < IDLENGTH/4; i++ {
+	for i := 0; i < len(binAddr)/4; i++ {
 		newPart := []rune(binAddr[(i * 4) : (i*4)+4])
 		newIntPart := 0
 		for j := 0; j < 4; j++ {

--- a/main/main.go
+++ b/main/main.go
@@ -47,7 +47,7 @@ func StartKademlia() {
 	if firstNode.Id != nodeId && firstNode.Id != "" {
 		rt.GiveOrder(kdmlib.OrderForRoutingTable{kdmlib.ADD, firstNode, false})
 	}
-	nw := kdmlib.InitNetwork(port, ip, rt, nodeId, false, chanFile, chanPin, fileMap)
+	nw := kdmlib.InitNetwork(port, ip, rt, nodeId, false, false, chanFile, chanPin, fileMap)
 	kdm := kdmlib.NewKademliaInstance(nw, nodeId, kdmlib.ALPHA, kdmlib.K, rt, chanFile, fileMap)
 	restApi.LaunchRestAPI(fileMap, chanFile, chanPin, *kdm)
 }

--- a/main/main.go
+++ b/main/main.go
@@ -13,7 +13,6 @@ import (
 
 func main() {
 	StartKademlia()
-
 }
 
 func SendAddress(ip string, port string, id string) kdmlib.AddressTriple {
@@ -35,8 +34,8 @@ func SendAddress(ip string, port string, id string) kdmlib.AddressTriple {
 }
 
 func StartKademlia() {
-	nodeId := kdmlib.GenerateRandID(int64(rand.Intn(100)))
-	rt := kdmlib.CreateAllWorkersForRoutingTable(kdmlib.K, kdmlib.IDLENGTH, 5, nodeId)
+	nodeId := kdmlib.GenerateRandID(int64(rand.Intn(100)), 160)
+	rt := kdmlib.CreateAllWorkersForRoutingTable(kdmlib.K, 160, 5, nodeId)
 
 	chanPin, chanFile, fileMap := fileUtilsKademlia.CreateAndLaunchFileWorkers()
 


### PR DESCRIPTION
- Fixed concurrency-related bugs, associated with exit strategies of lookup (now closing the worker channels).
- Added useful printout to get useful information during runtime.
- Tested the software with 160-bit IDs and added tests for 160-bit scenarios
- Using HEX to output node IDs.
- Using HEX filenames.
- Added another testflag to Network struct for storage testing.
- Other minor changes in Utils.